### PR TITLE
Only trim archetypes

### DIFF
--- a/src/Arch/Core/World.cs
+++ b/src/Arch/Core/World.cs
@@ -374,7 +374,6 @@ public partial class World : IDisposable
         Capacity = 0;
 
         // Trim entity info and archetypes
-        EntityInfo.TrimExcess();
         for (var index = Archetypes.Count - 1; index >= 0; index--)
         {
             // Remove empty archetypes.

--- a/src/Arch/Core/World.cs
+++ b/src/Arch/Core/World.cs
@@ -373,7 +373,11 @@ public partial class World : IDisposable
     {
         Capacity = 0;
 
-        // Trim entity info and archetypes
+        // Trim archetypes
+        // Upstream also trims EntityInfo HOWEVER this doesn't work correctly with pooled entity ids (AFAICT) as they
+        // may refer to indices that get removed.
+        // Additionally we can't just prune pooled entity ids because we need to make sure versions are intact
+        // or else we get duplicate entities which is MUCHO BAD.
         for (var index = Archetypes.Count - 1; index >= 0; index--)
         {
             // Remove empty archetypes.


### PR DESCRIPTION
In our case we absolutely need to make sure entityids are never re-used and if we trim EntityInfo there's a possibility of the versions getting re-used and I would rather just keep the entity array larger.